### PR TITLE
AlterColumn: skip columns not supported in dry run

### DIFF
--- a/migrator.go
+++ b/migrator.go
@@ -282,9 +282,14 @@ func (m Migrator) AlterColumn(value interface{}, field string) error {
 		if stmt.Schema != nil {
 			if field := stmt.Schema.LookUpField(field); field != nil {
 				var (
-					columnTypes, _  = m.DB.Migrator().ColumnTypes(value)
-					fieldColumnType *migrator.ColumnType
+					columnTypes, ctErr = m.DB.Migrator().ColumnTypes(value)
+					fieldColumnType    *migrator.ColumnType
 				)
+
+				// Skip ALTER for columns types that are not supported in dry run mode
+				if ctErr != nil && ctErr.Error() == "dry run not supported" {
+					return nil
+				}
 				for _, columnType := range columnTypes {
 					if columnType.Name() == field.DBName {
 						fieldColumnType, _ = columnType.(*migrator.ColumnType)


### PR DESCRIPTION
Money fields were causing nil pointer dereference errors because they weren't supported in GORM's dry run mode. This PR early returns in these cases to unblock other dry-run checks from happening:

Here were some logs that were used to help debug:
```
ALTER ERROR from ColumnTypes: dry run not supported, for more context one of the columns in creditCode is using *money.Money
ALTER schema: github.com/fw-ai/fireworks/control_plane/pkg/database.CreditCode
ALTER field &{Code Code [Code] string string false false 1 true true true 0 0 false  <nil> false true  0 0 0 false string string {Code  string gorm:"uniqueIndex" 16 [1] false} gorm:"uniqueIndex" map[UNIQUEINDEX:UNIQUEINDEX] github.com/fw-ai/fireworks/control_plane/pkg/database.CreditCode <nil> <nil> 0xa83480 0xa83a00 0xa806a0 <nil> 0xc000376a50}
ALTER dbfield Code
ALTER value: creditCodes/ (type: *database.CreditCode)
ALTER  ColumnTypes length: 0
ALTER stmt.Table: CreditCodes
ALTER column Code, table CreditCodes
ALTER fileType text
ALTER fieldColumnType: <nil>
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0xc1ffcd]
```
Thank you @ManikantaSanjay for helping with the debug!