### PR TITLE
AlterColumn: change error wording

### DIFF
--- a/migrator.go
+++ b/migrator.go
@@ -287,7 +287,7 @@ func (m Migrator) AlterColumn(value interface{}, field string) error {
 				)
 
 				// Skip ALTER for columns types that are not supported in dry run mode
-				if ctErr != nil && ctErr.Error() == "dry run not supported" {
+				if ctErr != nil && ctErr.Error() == "dry run mode unsupported" {
 					return nil
 				}
 				for _, columnType := range columnTypes {


### PR DESCRIPTION
The exact error is "dry run mode unsupported"

Testing now shows that ALTER actually works for Money fields as well!
```
runner@runnervmg1sw1:~/work/fireworks/fireworks/control_plane$ bin/automigrate_db --db_engine=postgres --postgres_host=localhost --postgres_user=postgres --postgres_password=my-password --postgres_database=control-plane-db --disable_timeout=true | grep -E 'ALTER|CREATE'
{"level":"info","name":"db_engine","value":"postgres","time":"2025-11-26T19:22:45.136329855Z"}
{"level":"info","name":"disable_timeout","value":"true","time":"2025-11-26T19:22:45.136372153Z"}
{"level":"info","name":"dry-run","value":"true","time":"2025-11-26T19:22:45.136376201Z"}
{"level":"info","name":"postgres_database","value":"control-plane-db","time":"2025-11-26T19:22:45.136382572Z"}
{"level":"info","name":"postgres_host","value":"localhost","time":"2025-11-26T19:22:45.136388283Z"}
{"level":"info","name":"postgres_password","value":"my-password","time":"2025-11-26T19:22:45.136391629Z"}
{"level":"info","name":"postgres_port","value":"5432","time":"2025-11-26T19:22:45.136395136Z"}
{"level":"info","name":"postgres_statement_timeout","value":"5000","time":"2025-11-26T19:22:45.136398482Z"}
{"level":"info","name":"postgres_user","value":"postgres","time":"2025-11-26T19:22:45.136401738Z"}
{"level":"info","name":"sqlite_filename","value":"","time":"2025-11-26T19:22:45.136404643Z"}
2025/11/26 19:22:45 Dry run. Not running the migration. Re-run with --dry-run=false to apply changes.
2025/11/26 19:22:45 Note: gorm's migrator is spammy, you might want to run it with `| grep -v 'SELECT description'`
ALTER dry run mode unsupported
SELECT description FROM pg_catalog.pg_description WHERE objsubid = (SELECT ordinal_position FROM information_schema.columns WHERE table_schema = CURRENT_SCHEMA() AND table_name = 'CreditCodes' AND column_name = 'Code') AND objoid = (SELECT oid FROM pg_catalog.pg_class WHERE relname = 'CreditCodes' AND relnamespace = (SELECT oid FROM pg_catalog.pg_namespace WHERE nspname = CURRENT_SCHEMA()));
ALTER TABLE "CreditCodes" ADD "Amount_CurrencyCode" text;
ALTER TABLE "CreditCodes" ADD "Amount_Units" bigint;
ALTER TABLE "CreditCodes" ADD "Amount_Nanos" integer;
```